### PR TITLE
Update README.md to recommend using the latest 1.+ release dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Add the library dependency to your `build.gradle` file:
 
 ```gradle
 dependencies {
-    implementation 'com.github.woheller69:FreeDroidWarn:V1.6'
+    implementation 'com.github.woheller69:FreeDroidWarn:V1.+'
 }
 ```
 


### PR DESCRIPTION
This PR changes the recommendation for including this library to use the most recent `V1.+` version of the dependency rather than needing to be hardwired at `V1.6`. This enables the library to release future versions with additional localizations or updated messaging (and calls to action), and the dependent apps will get the update automatically the next time they build/release without needing to manually update their dependencies.

We could alternatively recommend using [`latest.release`](https://docs.gradle.org/current/userguide/dependency_versions.html#sec:single-version-declarations).