### PR TITLE
Link to keepandroidopen.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Requiring developers to submit personal identity details to Google in order for 
 
 Developer verification will be enforced on certified devices with Google Play Services installed, which is the majority of Android devices. There are options to bypass the restriction:
 
+- [Make your voice heard - Keep Android Open](https://keepandroidopen.org/)
 - Use a free, uncensored Android system like [/e/os](https://e.foundation/e-os/), [LineageOS](https://lineageos.org/), or [GrapheneOS](https://grapheneos.org/) that does not preinstall Google Play Services.
 - "Degoogle" by removing Google Play Services. Depending on the manufacturer of your phone this may require [rooting your device](https://www.androidauthority.com/root-android-277350/).
 - Install apps via ADB. Google has already confirmed that ADB will continue to work in the future. You can either use ADB from a PC as described below or use a wireless ADB based installer like [anyapk](https://github.com/sam1am/anyapk).


### PR DESCRIPTION
Link to https://keepandroidopen.org/ in the section about solutions to Google's Android centralization.

I clicked the banner in the app and was visiting this site just before that.